### PR TITLE
don't create boto.cfg file if access key is nil #1

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-template "/etc/boto.cfg" do
-  source "boto.cfg.erb"
+unless node['boto']['aws_access_key_id'].nil?
+  template "/etc/boto.cfg" do
+    source "boto.cfg.erb"
+  end
 end


### PR DESCRIPTION
fix to issue #1

no need to create boto.cfg file if there is no access key specified
